### PR TITLE
feat: Add window close mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,13 @@ use({
         height = 5, -- integer >= 5 | float in range (0, 1)
         width = 0.55, -- integer | float in range (0, 1)
         border = "rounded", -- "none" | "single" | "double" | "rounded" | "shadow" | "solid"
-        close_with = nil, -- lhs used to close game window. nil means no map
+        -- lhs used to close game window.
+        -- can be a string (applies to normal mode),
+        -- or a table where the key represents the mode and the value is the mapping.
+        -- e.g. close_with = "q" or close_with = { n = "q", i = "<M-q>" }.
+        -- mode can be any of "n" | "i" | "x"
+        -- nil means no map
+        close_with = nil,
     },
     language = "en", -- "en" | "sr" currently only only supports English and Serbian
     sentence_mode = false, -- if true, whole sentences will be used

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ use({
         height = 5, -- integer >= 5 | float in range (0, 1)
         width = 0.55, -- integer | float in range (0, 1)
         border = "rounded", -- "none" | "single" | "double" | "rounded" | "shadow" | "solid"
+        close_with = nil, -- lhs used to close game window. nil means no map
     },
     language = "en", -- "en" | "sr" currently only only supports English and Serbian
     sentence_mode = false, -- if true, whole sentences will be used

--- a/lua/speedtyper/config.lua
+++ b/lua/speedtyper/config.lua
@@ -6,6 +6,7 @@ M.default_opts = {
         height = 5, -- integer >= 5 | float in range (0, 1)
         width = 0.55, -- integer | float in range (0, 1)
         border = "rounded", -- "none" | "single" | "double" | "rounded" | "shadow" | "solid"
+        close_with = nil, -- lhs used to close game window. nil means no map
     },
     language = "en", -- "en" | "sr" currently only only supports English and Serbian
     sentence_mode = false, -- if true, whole sentences will be used

--- a/lua/speedtyper/config.lua
+++ b/lua/speedtyper/config.lua
@@ -6,7 +6,13 @@ M.default_opts = {
         height = 5, -- integer >= 5 | float in range (0, 1)
         width = 0.55, -- integer | float in range (0, 1)
         border = "rounded", -- "none" | "single" | "double" | "rounded" | "shadow" | "solid"
-        close_with = nil, -- lhs used to close game window. nil means no map
+        -- lhs used to close game window.
+        -- can be a string (applies to normal mode),
+        -- or a table where the key represents the mode and the value is the mapping.
+        -- e.g. close_with = "q" or close_with = { n = "q", i = "<M-q>" }.
+        -- mode can be any of "n" | "i" | "x"
+        -- nil means no map
+        close_with = nil,
     },
     language = "en", -- "en" | "sr" currently only only supports English and Serbian
     sentence_mode = false, -- if true, whole sentences will be used

--- a/lua/speedtyper/util.lua
+++ b/lua/speedtyper/util.lua
@@ -101,10 +101,10 @@ function M.window_allowed_vim_mode(mode)
     if mode == nil or type(mode) ~= "string" then
         return false
     end
-   local allowed_vim_modes = {
-    "i",
-    "n",
-    "x",
+    local allowed_vim_modes = {
+        "i",
+        "n",
+        "x",
     }
     for _, val in ipairs(allowed_vim_modes) do
         if val == mode then

--- a/lua/speedtyper/util.lua
+++ b/lua/speedtyper/util.lua
@@ -94,4 +94,51 @@ function M.disable_modifying_buffer()
     end
 end
 
+---check if mode is allowed for floating window
+---@param mode string
+---@return boolean
+function M.window_allowed_vim_mode(mode)
+    if mode == nil or type(mode) ~= "string" then
+        return false
+    end
+   local allowed_vim_modes = {
+    "i",
+    "n",
+    "x",
+    }
+    for _, val in ipairs(allowed_vim_modes) do
+        if val == mode then
+            return true
+        end
+    end
+    return false
+end
+
+--- @param winnr integer
+--- @param bufnr integer
+--- @param mapping string | table<string, string>
+function M.set_window_close_mapping(winnr, bufnr, mapping)
+    if mapping == nil then
+        return
+    end
+    if type(mapping) == "string" then
+        vim.keymap.set("n", mapping, function()
+            api.nvim_win_close(winnr, false)
+        end, { buffer = bufnr })
+    elseif type(mapping) == "table" then
+        for mode, lhs in pairs(mapping) do
+            if not M.window_allowed_vim_mode(mode) then
+                M.error("Invalid mode " .. mode .. " skipping...")
+                goto continue
+            end
+            vim.keymap.set(mode, lhs, function()
+                api.nvim_win_close(winnr, false)
+            end, { buffer = bufnr })
+            ::continue::
+        end
+    else
+        M.error("Invalid type for window close mapping. Defaulting to noop")
+    end
+end
+
 return M

--- a/lua/speedtyper/util.lua
+++ b/lua/speedtyper/util.lua
@@ -129,12 +129,11 @@ function M.set_window_close_mapping(winnr, bufnr, mapping)
         for mode, lhs in pairs(mapping) do
             if not M.window_allowed_vim_mode(mode) then
                 M.error("Invalid mode " .. mode .. " skipping...")
-                goto continue
+            else
+                vim.keymap.set(mode, lhs, function()
+                    api.nvim_win_close(winnr, false)
+                end, { buffer = bufnr })
             end
-            vim.keymap.set(mode, lhs, function()
-                api.nvim_win_close(winnr, false)
-            end, { buffer = bufnr })
-            ::continue::
         end
     else
         M.error("Invalid type for window close mapping. Defaulting to noop")

--- a/lua/speedtyper/window.lua
+++ b/lua/speedtyper/window.lua
@@ -32,6 +32,11 @@ function M.open_float(opts)
         title_pos = "center",
         noautocmd = true,
     })
+    if opts.close_with ~= nil then
+        vim.keymap.set("n", opts.close_with, function()
+            api.nvim_win_close(winnr, false)
+        end)
+    end
     return winnr, bufnr
 end
 

--- a/lua/speedtyper/window.lua
+++ b/lua/speedtyper/window.lua
@@ -35,7 +35,7 @@ function M.open_float(opts)
     if opts.close_with ~= nil then
         vim.keymap.set("n", opts.close_with, function()
             api.nvim_win_close(winnr, false)
-        end)
+        end, { buffer = bufnr })
     end
     return winnr, bufnr
 end

--- a/lua/speedtyper/window.lua
+++ b/lua/speedtyper/window.lua
@@ -32,11 +32,7 @@ function M.open_float(opts)
         title_pos = "center",
         noautocmd = true,
     })
-    if opts.close_with ~= nil then
-        vim.keymap.set("n", opts.close_with, function()
-            api.nvim_win_close(winnr, false)
-        end, { buffer = bufnr })
-    end
+    require("speedtyper.util").set_window_close_mapping(winnr, bufnr, opts.close_with)
     return winnr, bufnr
 end
 


### PR DESCRIPTION
## 📃 Summary

This is a convenience feature that adds a new configuration option called "close_with" to the window opts which can be a string or a table.
If it's a string then it will be used as a normal mode mapping to close the window. If its a table then the key will be the mode and the val will be the key used to close the window in that mode. If it's nil (default) then no mapping will be added. I added this in my fork because it made the experience just a tad smoother for me. 

P.s I haven't tested this on earlier versions of nvim (I'm running on nightly) but I don't believe I used any methods not used already in this project.